### PR TITLE
fix(modal): unresponsive app when using both modal and popover

### DIFF
--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -242,7 +242,10 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
       }
 
       return $timeout(function() {
-        if (!modalStack.length) {
+        var modalOfTypeExists = modalStack.some(function(modal) {
+          return modal.viewType === self.viewType;
+        });
+        if (!modalOfTypeExists) {
           $ionicBody.removeClass(self.viewType + '-open');
         }
         self.el.classList.add('hide');


### PR DESCRIPTION
#### Short description of what this resolves:

When both a modal and popover are used at the same time there is the possibility of the "modal-open" or "popover-open" body classes not being removed when the modal or popover is hidden. Since these body classes have `pointer-events: none` in their styling the app becomes unresponsive.

See comment here: https://github.com/driftyco/ionic/commit/6ed7253#commitcomment-20105088

#### Changes proposed in this pull request:

Test only for the modal's viewType in the modalStack when deciding to remove the body class.

**Ionic Version**: 1.3.2

**Fixes**: #71
