### PR TITLE
fix(refresherController): do not assume that user-supplied promises have a…

### DIFF
--- a/js/angular/controller/refresherController.js
+++ b/js/angular/controller/refresherController.js
@@ -354,9 +354,24 @@ IonicModule
       var q = $scope.$onRefresh();
 
       if (q && q.then) {
-        q['finally'](function() {
-          $scope.$broadcast('scroll.refreshComplete');
-        });
+        if (q['finally']) {
+          q['finally'](broadcastRefreshEnd);
+        } else {
+          q.then(
+            function(payload) {
+              broadcastRefreshEnd();
+              return payload;
+            },
+            function(error) {
+              broadcastRefreshEnd();
+              throw error;
+            }
+          );
+        }
+      }
+
+      function broadcastRefreshEnd() {
+        $scope.$broadcast('scroll.refreshComplete');
       }
     }
 


### PR DESCRIPTION
… finally() method

Fallback to transparent then() instead

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #
