### PR TITLE
Set options to timeout, guaranteeing the variable "options" has been loaded

### DIFF
--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -147,18 +147,18 @@ function($animate, $timeout, $compile) {
         return _this.__slider;
       };
 
-      var options = $scope.options || {};
-
-      var newOptions = angular.extend({
-        pagination: $element.children().children()[1],
-        paginationClickable: true,
-        lazyLoading: true,
-        preloadImages: false
-      }, options);
-
-      this._options = newOptions;
-
       $timeout(function() {
+        var options = $scope.options || {};
+
+        var newOptions = angular.extend({
+          pagination: $element.children().children()[1],
+          paginationClickable: true,
+          lazyLoading: true,
+          preloadImages: false
+        }, options);
+
+        this._options = newOptions;
+
         var slider = new ionic.views.Swiper($element.children()[0], newOptions, $scope, $compile);
 
         $scope.$emit("$ionicSlides.sliderInitialized", { slider: slider });


### PR DESCRIPTION
#### Short description of what this resolves:
Options returned undefined in some cases.
Fixes Issue #47 

#### Changes proposed in this pull request:

- Move the assignment of options to newOptions into the 200ms timeout, allowing options to have been set externally.

**Ionic Version**: 1.x

**Fixes**:  Issue #47 
