### PR TITLE
Enable dragcontent to be right or left to handle RTL side menu support

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -329,6 +329,10 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
   // Handle a drag event
   self._handleDrag = function(e) {
     if (isAsideExposed || !$scope.dragContent) return;
+    //if dragContent is right
+    if ($scope.dragContent=='right' && !self.isOpenRight() && e.gesture.direction=='right')return;
+    //if dragContent is left
+    if ($scope.dragContent=='left' && !self.isOpenLeft() && e.gesture.direction=='left')return;
 
     // If we don't have start coords, grab and store them
     if (!startX) {
@@ -359,7 +363,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
 
   self.canDragContent = function(canDrag) {
     if (arguments.length) {
-      $scope.dragContent = !!canDrag;
+      $scope.dragContent = canDrag;
     }
     return $scope.dragContent;
   };

--- a/js/angular/directive/sideMenu.js
+++ b/js/angular/directive/sideMenu.js
@@ -28,21 +28,28 @@ IonicModule
   return {
     restrict: 'E',
     require: '^ionSideMenus',
-    scope: true,
+    scope: {side:'@?'},
     compile: function(element, attr) {
       angular.isUndefined(attr.isEnabled) && attr.$set('isEnabled', 'true');
       angular.isUndefined(attr.width) && attr.$set('width', '275');
 
-      element.addClass('menu menu-' + attr.side);
 
       return function($scope, $element, $attr, sideMenuCtrl) {
-        $scope.side = $attr.side || 'left';
-
+        $scope.side = $scope.side || 'left';
         var sideMenu = sideMenuCtrl[$scope.side] = new ionic.views.SideMenu({
           width: attr.width,
           el: $element[0],
           isEnabled: true
         });
+        $scope.$watch('side',function (value) {
+          element.removeClass('menu-right menu-left');
+          element.addClass('menu menu-' + $scope.side);
+           sideMenu = sideMenuCtrl[$scope.side] = new ionic.views.SideMenu({
+            width: attr.width,
+            el: $element[0],
+            isEnabled: true
+          });
+        })
 
         $scope.$watch($attr.width, function(val) {
           var numberVal = +val;
@@ -57,4 +64,3 @@ IonicModule
     }
   };
 });
-

--- a/js/angular/directive/sideMenuContent.js
+++ b/js/angular/directive/sideMenuContent.js
@@ -36,7 +36,9 @@ function($timeout, $ionicGesture, $window) {
   return {
     restrict: 'EA', //DEPRECATED 'A'
     require: '^ionSideMenus',
-    scope: true,
+    scope: {
+      dragContent:"@?"
+    },
     compile: function(element, attr) {
       element.addClass('menu-content pane');
 
@@ -46,7 +48,7 @@ function($timeout, $ionicGesture, $window) {
         var primaryScrollAxis = null;
 
         if (isDefined(attr.dragContent)) {
-          $scope.$watch(attr.dragContent, function(value) {
+          $scope.$watch('dragContent', function(value) {
             sideMenuCtrl.canDragContent(value);
           });
         } else {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": {
     "url": "git://github.com/ionic-team/ionic.git"
   },
+  "scripts":{
+    "gulp":"gulp"
+  },
   "devDependencies": {
     "canonical-path": "0.0.2",
     "chalk": "^0.4.0",


### PR DESCRIPTION
#### Short description of what this resolves:
On dynamic change of ion-side-menu `side` property to support RTL direction the menu is stopped working and need to reload the page to work again with `right` direction which is not a good practice for mobile UX.

#### Changes proposed in this pull request:

-  added two another options to `drag-content` to be `right` or `left`
-  added a `$watch` to detect if `drag-content` value changed at any point of time
-  preventing the slide of menu to right if the app direction is left and vise versa 

**Ionic Version**: 1.x 

**use case sample**
    
    <ion-side-menus enable-menu-with-back-views="false">
        <ion-side-menu-content drag-content="{{$root.direction}}">
           <ion-nav-bar class="bar-stable">
              <ion-nav-back-button>
              </ion-nav-back-button>

              <ion-nav-buttons side="{{$root.direction}}" >
                  <button class="button button-icon button-clear ion-navicon" menu-toggle="{{$root.direction}}">
                 </button>
              </ion-nav-buttons>

            </ion-nav-bar>
          <ion-nav-view name="menuContent"></ion-nav-view>
       </ion-side-menu-content >

       <ion-side-menu   side="{{$root.direction}}" >
         <!--menu goes here -->
       </ion-side-menu>

    </ion-side-menus>