### PR TITLE
fix(): update ios style fixes for ios 11.2 compatibility

### DIFF
--- a/scss/_platform.scss
+++ b/scss/_platform.scss
@@ -101,22 +101,28 @@
 @media (orientation: landscape) {
   .item {
     padding: $item-padding calc(constant(safe-area-inset-right) + #{$item-padding});
+    padding: $item-padding calc(env(safe-area-inset-right) + #{$item-padding});
 
     .badge {
-      right: calc(constant(safe-area-inset-right) + 32px)
+      right: calc(constant(safe-area-inset-right) + 32px);
+      right: calc(env(safe-area-inset-right) + 32px);
     }
   }
   .item-icon-left {
     padding-left: calc(constant(safe-area-inset-left) + 54px);
+    padding-left: calc(env(safe-area-inset-left) + 54px);
 
     .icon {
       left: calc(constant(safe-area-inset-left) + 11px);
+      left: calc(env(safe-area-inset-left) + 11px);
     }
   }
   .item-icon-right {
     padding-right: calc(constant(safe-area-inset-right) + 54px);
+    padding-right: calc(env(safe-area-inset-right) + 54px);
     .icon {
       right: calc(constant(safe-area-inset-right) + 11px);
+      right: calc(env(safe-area-inset-right) + 11px);
     }
   }
 
@@ -128,15 +134,21 @@
         calc(constant(safe-area-inset-right) + #{(ceil( ($item-padding * 3) + ($item-padding / 3)) - 5)})
         $item-padding
         calc(constant(safe-area-inset-left) + #{$item-padding});
+      padding: $item-padding
+        calc(env(safe-area-inset-right) + #{(ceil( ($item-padding * 3) + ($item-padding / 3)) - 5)})
+        $item-padding
+        calc(env(safe-area-inset-left) + #{$item-padding});
     }
   }
 
   .item-left-edit.visible.active {
     @include translate3d(calc(constant(safe-area-inset-left) + 8px), 0, 0);
+    @include translate3d(calc(env(safe-area-inset-left) + 8px), 0, 0);
   }
   .list-left-editing .item-left-editable .item-content,
   .item-left-editing.item-left-editable .item-content {
     @include translate3d(calc(constant(safe-area-inset-left) + 50px), 0, 0);
+    @include translate3d(calc(env(safe-area-inset-left) + 50px), 0, 0);
   }
 
   .item-right-edit{


### PR DESCRIPTION
#### Short description of what this resolves:

The already merged fix [add ios11 style fixes](https://github.com/ionic-team/ionic-v1/commit/046beff33407b156de92eac41e8716d8e6d7af4d) stopped working ios >= 11.2 because the CSS constant() function has been renamed to env().

#### Changes proposed in this pull request:

- add Properties with env() function and use constant() function as fallback.

**Ionic Version**: 1.x