### PR TITLE
Fix links to the ionic-plugin-keyboard repository

### DIFF
--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -14,7 +14,7 @@
  * which can cause layout issues such as pushing headers up and out of view.
  *
  * The keyboard fixes work best in conjunction with the
- * [Ionic Keyboard Plugin](https://github.com/ionic-team/ionic-plugins-keyboard),
+ * [Ionic Keyboard Plugin](https://github.com/ionic-team/ionic-plugin-keyboard),
  * although it will perform reasonably well without.  However, if you are using
  * Cordova there is no reason not to use the plugin.
  *
@@ -45,7 +45,7 @@
  *
  * ### Plugin Usage
  * Information on using the plugin can be found at
- * [https://github.com/ionic-team/ionic-plugins-keyboard](https://github.com/ionic-team/ionic-plugins-keyboard).
+ * [https://github.com/ionic-team/ionic-plugin-keyboard](https://github.com/ionic-team/ionic-plugin-keyboard).
  *
  * ----------
  *


### PR DESCRIPTION
#### Short description of what this resolves:

Fix links to the ionic-plugin-keyboard repo, I noticed they're broken.

#### Changes proposed in this pull request:

- URL corrections

**Ionic Version**: 1.x / 2.x

**Fixes**: #
