### PR TITLE
chore(): add note on end of ionic v1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **See the [Migration from Ionic 1 Guide](https://ionicframework.com/docs/reference/migration#migrating-from-ionic-10-to-ionic-40) for migration information.**
 
+**See [Ionic Support Policy](https://ionicframework.com/docs/reference/support#framework-maintenance-and-support-status) for the support status of each version of Ionic.** 
+
 **Visit https://ionicframework.com/docs for the latest Ionic documentation.**
 
 ----

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 ## Ionic 1.x
 
+**Support for Ionic v1 ended in January 2017. We strongly recommend upgrading to the latest version of Ionic.**
+
+**See the [Migration from Ionic 1 Guide](https://ionicframework.com/docs/reference/migration#migrating-from-ionic-10-to-ionic-40) for migration information.**
+
+**Visit https://ionicframework.com/docs for the latest Ionic documentation.**
+
+----
+
 This is the repo for Ionic 1.x. If you're looking for the latest version (>= 2.0) of Ionic, please visit the main [Ionic](https://github.com/ionic-team/ionic) repo.
 
 For new apps, we *strongly* recommend the [latest version of Ionic](https://github.com/ionic-team/ionic) which comes with the latest version of Angular, many new components, enhanced performance, and more.


### PR DESCRIPTION
Ionic v1 is no longer supported. Add a note to the documentation to reflect this.